### PR TITLE
feature/appveyor one ci test for feature/hotfix/develop branches

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,7 @@ environment:
     # https://www.appveyor.com/docs/windows-images-software/
     - job_name: Chef Inspec Tests (Windows Server 2019)
       job_depends_on: Lint Tests
+      job_branch: feature_hotfix
       job_group: Chef Inspec Tests
       appveyor_build_worker_image: Visual Studio 2019
 
@@ -88,6 +89,57 @@ for:
   - matrix:
       only:
         - job_depends_on: Lint Tests
+        - job_branch: feature_hotfix
+    branches:
+      only:
+        - /feature.*/
+        - /hotfix.*/
+        - develop
+    build_script:
+      - ps: Write-Host "build_script for $env:APPVEYOR_JOB_NAME"
+      # Saltstack needs to see the CI environment variable when run through test kitchen proxy driver
+      - ps: if (Test-Path env:CI) {[System.Environment]::SetEnvironmentVariable("CI", $Env:CI, "Machine")}
+      - ps: >
+          if (Test-Path env:WIN10DSC_USER_ADMIN_PASSWORD)
+          {[System.Environment]::SetEnvironmentVariable("WIN10DSC_USER_ADMIN_PASSWORD",
+          $Env:WIN10DSC_USER_ADMIN_PASSWORD, "Machine")}
+      # - ps: if ($env:CI -imatch 'True') {write-host 'IS CI'} else {write-host 'IS NOT CI'}
+      # - ps: ./scripts/appveyor_tools.ps1 -function sysinfo
+      - ps: $ErrorActionPreference = "Stop";
+      - ps: ./scripts/appveyor_tools.ps1 -function setup -program test-kitchen
+      - ps: >
+          ./scripts/appveyor_tools.ps1 -function uninstall -program apps-saltstack-will-install |
+          Select-String -Pattern 'True', 'False'  -NotMatch
+      - ps: c:\opscode\chefdk\bin\chef.bat exec bundle install
+      - ps: c:\opscode\chefdk\bin\chef.bat exec kitchen list
+      - ps: $ErrorActionPreference = "Continue";
+      - ps: mkdir c:\results
+      # - ps: if ($LastExitCode -ne 0) {write-host "last exit code $LastExitCode"; $host.SetShouldExit($LastExitCode)}
+    test_script:
+      - ps: Write-Host "test_script for $env:APPVEYOR_JOB_NAME"
+      - ps: c:\opscode\chefdk\bin\chef.bat exec kitchen test
+    deploy: off
+    on_failure:
+      - ps: >
+          if (Test-Path "c:\results\salt_minion.log" -PathType Leaf)
+          { Get-Content "c:\results\salt_minion.log" }
+      - ps: >
+          if (Test-Path ".kitchen/logs/py3-windows.log" -PathType Leaf)
+          { Get-Content ".kitchen/logs/py3-windows.log" }
+    on_finish:
+      - ps: Write-Host "on_finish for $env:APPVEYOR_JOB_NAME"
+      # uncomment to debug
+      # - ps: ./scripts/appveyor_tools.ps1 -function setup -program rdp
+      - ps: ./scripts/appveyor_tools.ps1 -function submit -results inspec_tests
+
+  - matrix:
+      only:
+        - job_depends_on: Lint Tests
+    branches:
+      except:
+        - /feature.*/
+        - /hotfix.*/
+        - develop
     build_script:
       - ps: Write-Host "build_script for $env:APPVEYOR_JOB_NAME"
       # Saltstack needs to see the CI environment variable when run through test kitchen proxy driver

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -91,7 +91,6 @@ for:
   - matrix:
       only:
         - job_branch: pre_release
-        - job_depends_on: Lint Tests
     branches:
       only:
         - /feature.*/
@@ -137,7 +136,6 @@ for:
   - matrix:
       only:
         - job_branch: release
-        - job_depends_on: Lint Tests
     branches:
       only:
         - master

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -90,8 +90,8 @@ for:
 
   - matrix:
       only:
-        - job_depends_on: Lint Tests
         - job_branch: pre_release
+        - job_depends_on: Lint Tests
     branches:
       only:
         - /feature.*/
@@ -136,8 +136,8 @@ for:
 
   - matrix:
       only:
-        - job_depends_on: Lint Tests
         - job_branch: release
+        - job_depends_on: Lint Tests
     branches:
       only:
         - master

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -136,10 +136,9 @@ for:
       only:
         - job_depends_on: Lint Tests
     branches:
-      except:
-        - /feature.*/
-        - /hotfix.*/
-        - develop
+      only:
+        - master
+        - /release.*/
     build_script:
       - ps: Write-Host "build_script for $env:APPVEYOR_JOB_NAME"
       # Saltstack needs to see the CI environment variable when run through test kitchen proxy driver

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ environment:
     # https://www.appveyor.com/docs/windows-images-software/
     - job_name: Chef Inspec Tests (Windows Server 2019)
       job_depends_on: Lint Tests
-      job_branch: feature_hotfix
+      job_branch: pre_release
       job_group: Chef Inspec Tests
       appveyor_build_worker_image: Visual Studio 2019
 
@@ -89,7 +89,7 @@ for:
   - matrix:
       only:
         - job_depends_on: Lint Tests
-        - job_branch: feature_hotfix
+        - job_branch: pre_release
     branches:
       only:
         - /feature.*/

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -19,11 +19,13 @@ environment:
 
     - job_name: Chef Inspec Tests (Windows Server 2016)
       job_depends_on: Lint Tests
+      job_branch: release
       job_group: Chef Inspec Tests
       appveyor_build_worker_image: Visual Studio 2017
 
     - job_name: Chef Inspec Tests (Windows Server 2012 R2)
       job_depends_on: Lint Tests
+      job_branch: release
       job_group: Chef Inspec Tests
       appveyor_build_worker_image: Visual Studio 2015
 
@@ -135,6 +137,7 @@ for:
   - matrix:
       only:
         - job_depends_on: Lint Tests
+        - job_branch: release
     branches:
       only:
         - master


### PR DESCRIPTION
### What does this PR do?
Appveyor will only test against one os image for feature, hotfix and develop branches.

### What issues does this PR fix or reference?

### Previous Behavior
Each push would test against windows 2019, 2016 and 2012.

### New Behavior
Pushes to feature, hotfix or develop branches will only test against the windows server 2019 image.

Pushes to release, and master branches will still test against 2019, 2016 and 2012 images.

### Tests written?

Yes

### Commits signed with GPG?

Yes